### PR TITLE
Correct generation test data command for Super Resolution model

### DIFF
--- a/models/super_resolution_nchw/README.md
+++ b/models/super_resolution_nchw/README.md
@@ -6,5 +6,5 @@ Download and extract [Super Resolution (with sample test data)](https://github.c
 
 Convert to `.npy` formatted files by:
 ```sh
-python3 gen_nhwc_test_data.py -d path\to\super_resolution -n super_resolution
+python3 gen_nchw_test_data.py -d path\to\super_resolution -n super_resolution
 ```


### PR DESCRIPTION
These test data under `super_resolution_nchw`  folder are for NCHW layout, @bbernhar so is it a typos here? 

Regarding to **gen_nchw_test_data.py** script, @bbernhar do you refer to our internal generate test data scripts? If so, current these scripts are still on our internal side.  @huningxin @Honry Any suggestion of opening them to external? Thanks.